### PR TITLE
Improve loot handling

### DIFF
--- a/advmodel/Player.py
+++ b/advmodel/Player.py
@@ -55,7 +55,7 @@ class Player:
      self.class_type = "Classless"
      self.name       = name
      self.level      = 1
-     self.xp         = 0 
+     self.xp         = 0
      self.max_hp     = 4
      self.max_mp     = 0
      self.damage     = 0
@@ -63,6 +63,8 @@ class Player:
      self.attack_die = 2
      self.initiative = 1
      self.story_progress = 0
+     self.inventory = []
+     self.gold = 0
   def create(self,class_type):
      self.class_type = class_type
      for i in range( len( self.class_list ) ):
@@ -97,3 +99,11 @@ class Player:
      return str(self.max_hp - self.damage) + "/" + str(self.max_hp)
   def get_attack_damage(self):
      return random.randint(1,self.attack_die)
+  def add_item(self,item):
+     self.inventory.append(item)
+  def get_inventory(self):
+     return list(self.inventory)
+  def add_gold(self,amount):
+     self.gold += amount
+  def get_gold(self):
+     return self.gold

--- a/json/StoryDefault.json
+++ b/json/StoryDefault.json
@@ -90,19 +90,21 @@
              "attack" : [ "bites!", "grabs with tiny claws!" ],
              "delay" : [ "scampers around" ]
           },
-          "loot" :
-          {
-             "item" : "rat pelt"
-          }
-       },
-       {
+         "loot" :
+         {
+            "item" : "rat pelt"
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
+      },
+      {
           "object_type" : "monster",
           "name" : "Furry Wolverine",
           "level" : 2,
           "battle" :
           {
              "attack" : [ "roars and lunges!", "tries to shake you in its mouth!" ]
-          }
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
        },
        {
           "object_type" : "monster",
@@ -112,18 +114,19 @@
           {
              "attack" : [ "slashes at you with his axe!", "tries to clobber you!" ]
           },
-          "loot" :
-          {
-             "item" : "obsidian axe",
-             "item" : "knife",
-             "gold" :
-             {
-                "minimum" : 50,
-                "random" : 100
-             }
-          }
-       },
-       {
+         "loot" :
+         {
+            "item" : "obsidian axe",
+            "item" : "knife",
+            "gold" :
+            {
+               "minimum" : 50,
+               "random" : 100
+            }
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
+      },
+      {
           "object_type" : "monster",
           "name" : "Assassin",
           "level" : 4,
@@ -131,19 +134,20 @@
           {
              "attack" : [ "tries to murder you!", "is about to murder the Chieftan!" ]
           },
-          "loot" :
-          {
-             "item" : "assassin's blade",
-             "gold" :
-             {
-                "minimum" : 100,
-                "random" : 200
-             },
-             "item" : "healing potion",
-             "item" : "poison salve"
-          }
-       },
-       {
+         "loot" :
+         {
+            "item" : "assassin's blade",
+            "gold" :
+            {
+               "minimum" : 100,
+               "random" : 200
+            },
+            "item" : "healing potion",
+            "item" : "poison salve"
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
+      },
+      {
           "object_type" : "monster",
           "name" : "Throk Chief of Wind",
           "level" : 6,
@@ -160,18 +164,19 @@
                 }
              }
           },
-          "loot" :
-          {
-             "item" : "Blade of Throk",
-             "gold" :
-             {
-                "minimum" : 200,
-                "random" : 200
-             },
-             "item" : "healing potion"
-          }
-       },
-       {
+         "loot" :
+         {
+            "item" : "Blade of Throk",
+            "gold" :
+            {
+               "minimum" : 200,
+               "random" : 200
+            },
+            "item" : "healing potion"
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
+      },
+      {
           "object_type" : "monster",
           "name" : "Groth Forest Chieftan",
           "level" : 6,
@@ -179,17 +184,18 @@
           {
              "attack" : [ "tries to unseat you from your growing empire.", "wields his axe with prowess.", "tries to headbutt!" ]
           },
-          "loot" :
-          {
-             "item" : "ancient helmet",
-             "gold" :
-             {
-                "minimum" : 15,
-                "random" : 10
-             }
-          }
-       },
-       {
+         "loot" :
+         {
+            "item" : "ancient helmet",
+            "gold" :
+            {
+               "minimum" : 15,
+               "random" : 10
+            }
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
+      },
+      {
           "object_type" : "monster",
           "name" : "Strange Chieftan",
           "level" : 7,
@@ -197,16 +203,17 @@
           {
              "attack" : [ "wields razor sharp claws!", "intends to rule over all of the clans.  He attacks!" ]
           },
-          "loot" :
-          {
-             "gold" :
-             {
-                "minimum" : 1500,
-                "random" : 1000
-             }
-          }
-       },
-       {
+         "loot" :
+         {
+            "gold" :
+            {
+               "minimum" : 1500,
+               "random" : 1000
+            }
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
+      },
+      {
           "object_type" : "monster",
           "name" : "Frost Giant",
           "level" : 8,
@@ -237,14 +244,15 @@
                 "name" : "ruby",
                 "chance" : 50
              },
-             "item" :
-             {
-                "name" : "ingot",
-                "chance" : 30
-             }
-          }
-       },
-       {
+            "item" :
+            {
+               "name" : "ingot",
+               "chance" : 30
+            }
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
+      },
+      {
           "object_type" : "monster",
           "name" : "Spirit of the Curse",
           "level" : 9,
@@ -282,8 +290,9 @@
                       "random" : 15
                    }
                 }
-             ]  
-          }
+            ]
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
        },
        {
           "object_type" : "monster",
@@ -316,10 +325,11 @@
                       "random" : 150
                    }
                 }
-             ]  
-          }
-       }
-     ],
+            ]
+          },
+          "corpse_message" : "You found %s on its smoldering corpse!"
+      }
+    ],
      "items" :
      [
        {

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -7,3 +7,21 @@ def test_use_mp_decreases_mp():
     initial_mp = player.get_mp()
     player.use_mp(5)
     assert player.get_mp() == initial_mp - 5
+
+from advmodel.Monster import Monster
+
+def test_reward_adds_loot_to_inventory():
+    player = Player("LootTester")
+    player.create("Fighter")
+    monster = Monster()
+    monster.loot = {"item": "rat pelt"}
+    monster.reward(player)
+    assert "rat pelt" in player.get_inventory()
+
+def test_reward_adds_gold_to_player():
+    player = Player("GoldTester")
+    player.create("Fighter")
+    monster = Monster()
+    monster.loot = {"gold": {"minimum": 10, "random": 0}}
+    monster.reward(player)
+    assert player.get_gold() == 10


### PR DESCRIPTION
## Summary
- expand Player with gold tracking
- parse complex loot data in `Monster.reward`
- stop logging loot, display a corpse loot message
- store loot message in monster definitions
- test awarding both item and gold loot

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*